### PR TITLE
added postcss-url support

### DIFF
--- a/packages/kaizen-tg/_templates/drupal-8-theme/new/package.json.t
+++ b/packages/kaizen-tg/_templates/drupal-8-theme/new/package.json.t
@@ -55,6 +55,7 @@ to: <%= h.src() %>/<%= h.changeCase.lower(name) %>/package.json
     "postcss-nested": "^4.1.2",
     "postcss-preset-env": "^6.7.0",
     "postcss-pxtorem": "^6.0.0",
+    "postcss-url": "^10.1.3",
     "prettier": "^2.3.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",

--- a/packages/kaizen-tg/_templates/drupal-8-theme/new/postcss.config.js
+++ b/packages/kaizen-tg/_templates/drupal-8-theme/new/postcss.config.js
@@ -8,6 +8,7 @@ const postCssDrupalBreakpoints = require('@skilld/kaizen-breakpoints/postcss-plu
 const postcssNested = require('postcss-nested');
 const postcssDiscardEmpty = require('postcss-discard-empty');
 const pxtorem = require('postcss-pxtorem');
+const postcssUrl = require('postcss-url');
 const stylelint = require('stylelint');
 <% if (type === 'primary') {-%>
 const tailwind = require('tailwindcss');
@@ -18,6 +19,16 @@ module.exports = () => ({
   map: false,
   plugins: [
     postcssImport(),
+    postcssUrl(
+      {
+        url: 'inline',
+        basePath: [
+          '../../',
+          '../../../',
+          '../../../../',
+        ],
+      },
+    ),
 <% if (type === 'primary') {-%>
     tailwind(),
 <% } -%>

--- a/packages/kaizen-tg/package.json
+++ b/packages/kaizen-tg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/kaizen-tg",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Kaizen drupal theme generator",
   "bin": "index.js",
   "main": "index.js",

--- a/starterkits/basic/package.json
+++ b/starterkits/basic/package.json
@@ -50,6 +50,7 @@
     "postcss-nested": "^4.1.2",
     "postcss-preset-env": "^6.7.0",
     "postcss-pxtorem": "^6.0.0",
+    "postcss-url": "^10.1.3",
     "prettier": "^2.3.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",

--- a/starterkits/basic/postcss.config.js
+++ b/starterkits/basic/postcss.config.js
@@ -5,12 +5,23 @@ const postCssDrupalBreakpoints = require('@skilld/kaizen-breakpoints/postcss-plu
 const postcssNested = require('postcss-nested');
 const postcssDiscardEmpty = require('postcss-discard-empty');
 const pxtorem = require('postcss-pxtorem');
+const postcssUrl = require('postcss-url');
 const stylelint = require('stylelint');
 
 module.exports = () => ({
   map: false,
   plugins: [
     postcssImport(),
+    postcssUrl(
+      {
+        url: 'inline',
+        basePath: [
+          '../../',
+          '../../../',
+          '../../../../',
+        ],
+      },
+    ),
     postCssDrupalBreakpoints({
       importFrom: './kaizen.breakpoints.yml',
       themeName: 'kaizen'

--- a/starterkits/basic/yarn.lock
+++ b/starterkits/basic/yarn.lock
@@ -5026,6 +5026,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -8414,7 +8419,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0, make-dir@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -8732,7 +8737,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.4.4:
+mime@^2.4.4, mime@~2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
@@ -8764,7 +8769,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@3.0.x, minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@3.0.x, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -10228,6 +10233,16 @@ postcss-syntax@^0.36.2:
   version "0.36.2"
   resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.36.2.tgz#f08578c7d95834574e5593a82dfbfa8afae3b51c"
   integrity sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==
+
+postcss-url@^10.1.3:
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-10.1.3.tgz#54120cc910309e2475ec05c2cfa8f8a2deafdf1e"
+  integrity sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==
+  dependencies:
+    make-dir "~3.1.0"
+    mime "~2.5.2"
+    minimatch "~3.0.4"
+    xxhashjs "~0.2.2"
 
 postcss-value-parser@^3.3.0:
   version "3.3.1"
@@ -13505,6 +13520,13 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xxhashjs@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Now you can call images stored at `/images` folder for your `background-image` or `filter`

Example:
`background-image: url('images/svg/test.svg');`

Compiled:
`background-image: url("data:image/svg+xml,......");`

You can use it from the files stored at:
1. `src/css/*.css`
2. `src/css/**/*.css`
3. `packages/components/**/**/*.css`

But you still have to use svg-sprite as much as possible, because a lot of reasons: read why https://kb.skilld.cloud/all-you-have-know-about-svg-and-svg-sprites

so `postcss-url` should help you very rarely, for example when little `jpg` or `png` images you have, which can be called from theme and can live without drupal image styles.