### PR TITLE
updates for drupal breakpoints

### DIFF
--- a/packages/kaizen-breakpoints/package.json
+++ b/packages/kaizen-breakpoints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/kaizen-breakpoints",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Breakpoints YML to css and js",
   "repository": {
     "type": "git",

--- a/packages/kaizen-breakpoints/parse-breakpoints.js
+++ b/packages/kaizen-breakpoints/parse-breakpoints.js
@@ -57,7 +57,7 @@ function generateJSON(groups, fileContent) {
  * @returns
  */
 
-function generateQuery(breakpoint, multiplier) {
+function generateQuery(breakpoint, multiplier = undefined) {
   const resQuery = multiplier ? xToResolution(multiplier) : '';
   return breakpoint.mediaQuery + resQuery;
 }
@@ -116,6 +116,7 @@ function getBreakpointsByGroupsList(groups, fileContent) {
 
       multipliers.forEach(mp => {
         const multiplier = mp ? `_${mp}` : '';
+        output[group][breakpointLabel] = generateQuery(breakpoint);
         output[group][breakpointLabel + multiplier] = generateQuery(
           breakpoint,
           mp === '1x' ? null : mp,

--- a/packages/kaizen-breakpoints/postcss-plugin.js
+++ b/packages/kaizen-breakpoints/postcss-plugin.js
@@ -16,10 +16,13 @@ module.exports = postcss.plugin('postcss-drupal-breakpoints', function (opts) {
     return function (root) {
 
       root.walkAtRules(atRule => {
-        if (atRule.name === 'drupal-breakpoint') {
-          const media = breakpoints[themeName][atRule.params]
-          atRule.name = 'media'
-          atRule.params = media
+        switch (atRule.name) {
+          case 'drupal-breakpoint':
+          case 'db':
+            const media = breakpoints[themeName][atRule.params]
+            atRule.name = 'media'
+            atRule.params = media
+            break;
         }
       })
     }

--- a/packages/kaizen-core/_typography.css
+++ b/packages/kaizen-core/_typography.css
@@ -1,7 +1,7 @@
 html {
   font-size: var(--root-font-size--mobile);
 
-  @drupal-breakpoint l_1x {
+  @db l {
     font-size: var(--root-font-size--desktop);
   }
 }

--- a/packages/kaizen-core/package.json
+++ b/packages/kaizen-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/kaizen-core",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Kaizen core styles",
   "main": "index.js",
   "repository": {

--- a/packages/kaizen-tg/_templates/drupal-8-theme/new/.stylelintrc
+++ b/packages/kaizen-tg/_templates/drupal-8-theme/new/.stylelintrc
@@ -456,7 +456,7 @@ to: <%= h.src() %>/<%= h.changeCase.lower(name) %>/.stylelintrc
     "selector-pseudo-element-colon-notation": null,
     "shorthand-property-no-redundant-values": null,
     "string-quotes": "double",
-    "unit-allowed-list": ["deg", "em", "ex", "fr", "ms", "rem", "%", "s", "px", "vw", "vh"]
+    "unit-allowed-list": ["deg", "dppx", "em", "ex", "fr", "ms", "rem", "%", "s", "px", "vw", "vh"]
   },
   "ignoreFiles": [
     "assets/vendor/**/*.css",

--- a/packages/kaizen-tg/_templates/drupal-8-theme/new/package.json.t
+++ b/packages/kaizen-tg/_templates/drupal-8-theme/new/package.json.t
@@ -26,8 +26,8 @@ to: <%= h.src() %>/<%= h.changeCase.lower(name) %>/package.json
     "twig-loader": "^0.5.5"
   },
   "dependencies": {
-    "@skilld/kaizen-breakpoints": "^1.0.0",
-    "@skilld/kaizen-core": "^1.0.3",
+    "@skilld/kaizen-breakpoints": "^1.0.1",
+    "@skilld/kaizen-core": "^1.0.4",
 <% if(type==='primary'){ -%>
     "@skilld/kaizen-primary": "^1.0.1",
 <% } -%>

--- a/starterkits/basic/.stylelintrc
+++ b/starterkits/basic/.stylelintrc
@@ -453,7 +453,7 @@
     "selector-pseudo-element-colon-notation": null,
     "shorthand-property-no-redundant-values": null,
     "string-quotes": "double",
-    "unit-allowed-list": ["deg", "em", "ex", "fr", "ms", "rem", "%", "s", "px", "vw", "vh"]
+    "unit-allowed-list": ["deg", "dppx", "em", "ex", "fr", "ms", "rem", "%", "s", "px", "vw", "vh"]
   },
   "ignoreFiles": [
     "assets/vendor/**/*.css",


### PR DESCRIPTION
Now from css you will be able to use "@db" declaration of media query instead of old "@drupal-breakpoint".

Example of old syntax:

```
@drupal-breakpoint l_1x { ... }
```

Example of new syntax:

```
@db l { ... }
```

So, for `1x` multiplier its caption can be ignored in query call.
But support of old syntax wasn't kicked and old projects can be easily upgraded

Now here is a list of all possible drupal-breakpoint declarations available:

```
@db l { ... } // Same as old @drupal-breakpoint l_1x { ... }
@db l_1x { ... }
@db l_2x { ... }
@drupal-breakpoint l { ... } // Sams as @drupal-breakpoint l_1x { ... }
@drupal-breakpoint l_1x { ... }
@drupal-breakpoint l_2x { ... }
```