### PR TITLE
external-styles-include

### DIFF
--- a/packages/kaizen-tg/_templates/drupal-9-theme/new/.stylelintignore
+++ b/packages/kaizen-tg/_templates/drupal-9-theme/new/.stylelintignore
@@ -2,3 +2,5 @@
 to: <%= h.src() %>/<%= h.changeCase.lower(name) %>/.stylelintignore
 ---
 /color/*.css
+dist/**/**/**/*.css
+*_external.css

--- a/packages/kaizen-tg/_templates/drupal-9-theme/new/packages/components/component_example_external.css
+++ b/packages/kaizen-tg/_templates/drupal-9-theme/new/packages/components/component_example_external.css
@@ -1,0 +1,4 @@
+/* uncomment next line to import css file external */
+/*
+@import "libraryURL/css";
+*/

--- a/packages/kaizen-tg/_templates/drupal-9-theme/new/src/css/components/example_external.css
+++ b/packages/kaizen-tg/_templates/drupal-9-theme/new/src/css/components/example_external.css
@@ -1,0 +1,2 @@
+/* uncomment next line to import css file external */
+/* @import "@themeName/components/component_example_external"; */

--- a/packages/kaizen-tg/package.json
+++ b/packages/kaizen-tg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/kaizen-tg",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-alpha.6",
   "description": "Kaizen drupal theme generator",
   "bin": "index.js",
   "main": "index.js",


### PR DESCRIPTION
Temporary way to include external library styles with linter exclude.

Target to gather all component styles in one place. In this case on the storybook component.
In this temporary way - include CSS file from a library inside a separate file on the storybook side.
Than include this file separately - on storybook, and on Drupal side.
For the linter - added exclusion for the files that have names ending on *_external.css